### PR TITLE
Bump version to v3

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Helper action to remotely check if a docker image exists.
   # Check to see if this image is already built (and if so, skip further steps).
   - name: Check for existing image
     id: existing-image
-    uses: javajawa/check-registry-for-image@v2
+    uses: javajawa/check-registry-for-image@v3
     with:
       registry: ${{ env.DOCKER_REGISTRY }}  # e.g. https://aws_account_id.dkr.ecr.us-west-2.amazonaws.com
       repository: ${{ env.REPOSITORY }}     # my-awesome-project/server


### PR DESCRIPTION
Dropping support for old versions of node is not a backwards compatible change. As such the v2.1 release which was intended as a dependency upgrade has been moved to v3

This will resolve #7